### PR TITLE
Adds Comment Support

### DIFF
--- a/inc/class-wp-object.php
+++ b/inc/class-wp-object.php
@@ -48,6 +48,10 @@ abstract class WP_Object {
 			case 'user':
 				$meta = (array) get_user_meta( $this->object_id );
 				break;
+
+			case 'comment':
+				$meta = (array) get_comment_meta( $this->object_id );
+				break;
 		}
 
 		// Build data array [ key, value ].

--- a/inc/objects/class-comment.php
+++ b/inc/objects/class-comment.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Inspect comments.
+ *
+ * @package Meta_Inspector
+ */
+
+namespace Meta_Inspector;
+
+/**
+ * Inspect meta for users.
+ */
+class Comment extends WP_Object {
+
+	use Singleton;
+
+	/**
+	 * Object type.
+	 *
+	 * @var string
+	 */
+	public $type = 'comment';
+
+	/**
+	 * Initialize class.
+	 */
+	public function setup() {
+		add_action( 'add_meta_boxes', [ $this, 'add_meta_boxes' ] );
+	}
+
+	/**
+	 * Add meta boxes to the post edit screen.
+	 */
+	public function add_meta_boxes() {
+
+		// Store comment ID.
+		$this->object_id = get_comment_ID();
+
+		// Post meta.
+		add_meta_box(
+			'meta-inspector-comment-meta',
+			__( 'Comment Meta', 'meta-inspector' ),
+			[ $this, 'render_meta' ],
+			$this->type,
+			'normal'
+		);
+	}
+
+	/**
+	 * Render a table of post meta.
+	 */
+	public function render_meta() {
+		$this->render_meta_table();
+	}
+}

--- a/meta-inspector.php
+++ b/meta-inspector.php
@@ -34,6 +34,7 @@ require_once META_INSPECTOR_PATH . '/inc/class-wp-object.php';
 require_once META_INSPECTOR_PATH . '/inc/objects/class-post.php';
 require_once META_INSPECTOR_PATH . '/inc/objects/class-term.php';
 require_once META_INSPECTOR_PATH . '/inc/objects/class-user.php';
+require_once META_INSPECTOR_PATH . '/inc/objects/class-comment.php';
 
 // Initalize classes.
 add_action(
@@ -44,6 +45,7 @@ add_action(
 			Post::instance();
 			Term::instance();
 			User::instance();
+			Comment::instance();
 		}
 	}
 );


### PR DESCRIPTION
Extends existing functionality to add support for displaying meta attached to WP comments.

<img width="100%" alt="Screen Shot 2019-09-25 at 12 54 30 PM" src="https://user-images.githubusercontent.com/3642037/65622452-ae5c9380-df93-11e9-8082-66b7dad773c6.png">


This PR would resolve #3