### PR TITLE
Support for BuddyPress Group Meta

### DIFF
--- a/inc/class-wp-object.php
+++ b/inc/class-wp-object.php
@@ -53,6 +53,10 @@ abstract class WP_Object {
 				$meta = (array) get_comment_meta( $this->object_id );
 				break;
 
+			case 'bp-group':
+				$meta = (array) groups_get_groupmeta( $this->object_id, '', false );
+				break;
+
 			case 'fm-term-meta':
 				if ( function_exists( 'fm_get_term_meta' ) ) {
 					$term = get_term( $this->object_id );

--- a/inc/objects/class-bp-group.php
+++ b/inc/objects/class-bp-group.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Inspect groups.
+ *
+ * @package Meta_Inspector
+ */
+
+namespace Meta_Inspector;
+
+/**
+ * Inspect meta for a BuddyPress group.
+ */
+class BP_Group extends WP_Object {
+	use Singleton;
+
+	/**
+	 * Object type.
+	 *
+	 * @var string
+	 */
+	public $type = 'bp-group';
+
+	/**
+	 * Initialize class.
+	 */
+	protected function __construct() {
+
+		// Bail if BuddyPress groups are not active.
+		if ( ! bp_is_active( 'groups' ) ) {
+			return;
+		}
+
+		add_action( 'bp_groups_admin_meta_boxes', [ $this, 'add_meta_boxes' ] );
+	}
+
+	/**
+	 * Add meta boxes to the BuddyPress group edit screen.
+	 */
+	public function add_meta_boxes() {
+
+		// Store group ID.
+		$this->object_id = $_GET['gid'] ?? 0;
+
+		// Group meta.
+		add_meta_box(
+			'meta-inspector-bp-group-meta',
+			__( 'Meta', 'meta-inspector' ),
+			[ $this, 'render_meta' ],
+			get_current_screen()->id,
+			'normal'
+		);
+	}
+
+	/**
+	 * Render a table of group meta.
+	 */
+	public function render_meta() {
+		$this->render_meta_table();
+	}
+}

--- a/inc/objects/class-bp-group.php
+++ b/inc/objects/class-bp-group.php
@@ -39,7 +39,7 @@ class BP_Group extends WP_Object {
 	public function add_meta_boxes() {
 
 		// Store group ID.
-		$this->object_id = (int) sanitize_text_field( wp_unslash( $_GET['gid'] ?? 0 ) );
+		$this->object_id = (int) sanitize_text_field( wp_unslash( $_GET['gid'] ?? 0 ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		// Group meta.
 		add_meta_box(

--- a/inc/objects/class-bp-group.php
+++ b/inc/objects/class-bp-group.php
@@ -39,7 +39,7 @@ class BP_Group extends WP_Object {
 	public function add_meta_boxes() {
 
 		// Store group ID.
-		$this->object_id = $_GET['gid'] ?? 0;
+		$this->object_id = (int) sanitize_text_field( wp_unslash( $_GET['gid'] ?? 0 ) );
 
 		// Group meta.
 		add_meta_box(

--- a/inc/objects/class-comment.php
+++ b/inc/objects/class-comment.php
@@ -8,7 +8,7 @@
 namespace Meta_Inspector;
 
 /**
- * Inspect meta for users.
+ * Inspect meta for comments.
  */
 class Comment extends WP_Object {
 	use Singleton;
@@ -28,7 +28,7 @@ class Comment extends WP_Object {
 	}
 
 	/**
-	 * Add meta boxes to the post edit screen.
+	 * Add meta boxes to the comment edit screen.
 	 */
 	public function add_meta_boxes() {
 
@@ -40,7 +40,7 @@ class Comment extends WP_Object {
 		// Store comment ID.
 		$this->object_id = get_comment_ID();
 
-		// Post meta.
+		// Comment meta.
 		add_meta_box(
 			'meta-inspector-comment-meta',
 			__( 'Comment Meta', 'meta-inspector' ),
@@ -51,7 +51,7 @@ class Comment extends WP_Object {
 	}
 
 	/**
-	 * Render a table of post meta.
+	 * Render a table of comment meta.
 	 */
 	public function render_meta() {
 		$this->render_meta_table();

--- a/meta-inspector.php
+++ b/meta-inspector.php
@@ -26,6 +26,7 @@ require_once __DIR__ . '/inc/objects/class-term.php';
 require_once __DIR__ . '/inc/objects/class-user.php';
 require_once __DIR__ . '/inc/objects/class-comment.php';
 require_once __DIR__ . '/inc/objects/class-fm-term-meta.php';
+require_once __DIR__ . '/inc/objects/class-bp-group.php';
 
 // Initalize classes.
 add_action(
@@ -46,5 +47,10 @@ add_action(
 		Comment::instance();
 		// Legacy FM Term Meta Data support.
 		Fm_Term_Meta::instance();
+
+		// BuddyPress support.
+		if ( class_exists( 'BuddyPress' ) ) {
+			BP_Group::instance();
+		}
 	}
 );

--- a/meta-inspector.php
+++ b/meta-inspector.php
@@ -6,7 +6,7 @@
  * Author URI:      https://alley.com
  * Text Domain:     meta-inspector
  * Domain Path:     /languages
- * Version:         1.1.0
+ * Version:         1.1.1
  *
  * @package         Meta_Inspector
  */


### PR DESCRIPTION
Add support for a BuddyPress group meta.

<img width="2347" alt="Screenshot 2023-09-11 at 23 18 42" src="https://github.com/alleyinteractive/meta-inspector/assets/19148962/81966102-dc22-4a85-a7cc-eaf0dc846462">
