### PR TITLE
Support for BuddyPress Activity Meta

### DIFF
--- a/inc/class-wp-object.php
+++ b/inc/class-wp-object.php
@@ -58,6 +58,10 @@ abstract class WP_Object {
 				$meta = (array) groups_get_groupmeta( $this->object_id, '', false );
 				break;
 
+			case 'bp-activity':
+				$meta = (array) bp_activity_get_meta( $this->object_id, '', false );
+				break;
+
 			case 'fm-term-meta':
 				if ( function_exists( 'fm_get_term_meta' ) ) {
 					$term = get_term( $this->object_id );

--- a/inc/objects/class-bp-activity.php
+++ b/inc/objects/class-bp-activity.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Inspect BuddyPress activities.
+ *
+ * @package Meta_Inspector
+ */
+
+namespace Meta_Inspector;
+
+/**
+ * Inspect meta for BuddyPress activities.
+ */
+class BP_Activity extends WP_Object {
+	use Singleton;
+
+	/**
+	 * Object type.
+	 *
+	 * @var string
+	 */
+	public $type = 'bp-activity';
+
+	/**
+	 * Initialize class.
+	 */
+	protected function __construct() {
+
+		// Bail if the BuddyPress activity component is not active.
+		if ( ! bp_is_active( 'activity' ) ) {
+			return;
+		}
+
+		add_action( 'bp_activity_admin_meta_boxes', [ $this, 'add_meta_boxes' ] );
+	}
+
+	/**
+	 * Add meta boxes to the BuddyPress activity edit screen.
+	 */
+	public function add_meta_boxes() {
+
+		// Ensure the activity id is set.
+		if ( ! isset( $_GET['aid'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+
+		// Store activity id.
+		$this->object_id = (int) sanitize_text_field( wp_unslash( $_GET['aid'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		// Get screen id.
+		$screen_id = get_current_screen()->id;
+
+		// Activity meta.
+		add_meta_box(
+			'meta-inspector-bp-activity-meta',
+			__( 'Meta', 'meta-inspector' ),
+			fn () => $this->render_meta_table(),
+			$screen_id,
+			'normal'
+		);
+	}
+}

--- a/inc/objects/class-bp-group.php
+++ b/inc/objects/class-bp-group.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Inspect groups.
+ * Inspect BuddyPress groups.
  *
  * @package Meta_Inspector
  */
@@ -25,7 +25,7 @@ class BP_Group extends WP_Object {
 	 */
 	protected function __construct() {
 
-		// Bail if BuddyPress groups are not active.
+		// Bail if the BuddyPress groups component is not active.
 		if ( ! bp_is_active( 'groups' ) ) {
 			return;
 		}

--- a/meta-inspector.php
+++ b/meta-inspector.php
@@ -26,6 +26,7 @@ require_once __DIR__ . '/inc/objects/class-user.php';
 require_once __DIR__ . '/inc/objects/class-comment.php';
 require_once __DIR__ . '/inc/objects/class-fm-term-meta.php';
 require_once __DIR__ . '/inc/objects/class-bp-group.php';
+require_once __DIR__ . '/inc/objects/class-bp-activity.php';
 
 // Initalize classes.
 add_action(
@@ -44,12 +45,14 @@ add_action(
 		Term::instance();
 		User::instance();
 		Comment::instance();
+
 		// Legacy FM Term Meta Data support.
 		Fm_Term_Meta::instance();
 
 		// BuddyPress support.
 		if ( class_exists( 'BuddyPress' ) ) {
 			BP_Group::instance();
+			BP_Activity::instance();
 		}
 	}
 );


### PR DESCRIPTION
Add support for a BuddyPress activity meta.

<img width="2046" alt="Screenshot 2024-02-11 at 12 19 24 AM" src="https://github.com/alleyinteractive/meta-inspector/assets/19148962/82bb6e09-2faf-4dad-976f-4ba6fb1ae7ae">
